### PR TITLE
don't depend on PNP config from the kernel

### DIFF
--- a/default.script
+++ b/default.script
@@ -16,3 +16,12 @@ case "$1" in
   ;;
 esac
 
+RESOLV_CONF="/etc/resolv.conf"
+
+echo -n > $RESOLV_CONF
+[ -n "$domain" ] && echo domain $domain >> $RESOLV_CONF
+for i in $dns
+do
+  echo adding dns $i
+  echo nameserver $i >> $RESOLV_CONF
+done

--- a/init
+++ b/init
@@ -66,7 +66,7 @@ fi
 
 echo "Mount NFS ..."
 mount -t nfs -o nolock ${NFSOPTS} ${NFSROOT} /newroot||/bin/busybox sh -i </dev/console >/dev/console 2>&1
-cat /proc/net/pnp > /newroot/etc/resolv.conf||true
+cat /etc/resolv.conf > /newroot/etc/resolv.conf||true
 
 mount --move /proc /newroot/proc
 mount --move /sys /newroot/sys


### PR DESCRIPTION
Make the initrd work on distro kernels that don't enables PNP config.

Suggested-by: Steve McIntyre steve.mcintyre@linaro.org
Signed-off-by: Anders Roxell anders.roxell@linaro.org
